### PR TITLE
Support Scala 2.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,15 +20,15 @@ jobs:
     steps:
     - name: Checkout current branch
       uses: actions/checkout@v3
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'temurin'
         check-latest: true
         cache: 'sbt'
     - name: Run tests
-      run: sbt test
+      run: sbt lint testAll
 
   publish:
     runs-on: ubuntu-latest
@@ -37,10 +37,10 @@ jobs:
     steps:
       - name: Checkout current branch
         uses: actions/checkout@v3
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
           check-latest: true
           cache: 'sbt'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout current branch
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Set up JDK 17
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: '17'
         distribution: 'temurin'
@@ -36,9 +36,9 @@ jobs:
     if: github.event_name == 'release'
     steps:
       - name: Checkout current branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/README.md
+++ b/README.md
@@ -23,3 +23,10 @@ Inline files with extension `.txt` in sub folder `folder1/folder2` under `./inli
 ```
 
 See all examples in [tests](inline-files/src/test/scala/frawa/inlinefiles/InlineFilesTest.scala).
+
+
+## References
+
+- https://docs.scala-lang.org/scala3/guides/migration/tutorial-macro-mixing.html
+- https://www.scala-sbt.org/1.x/docs/Cross-Build.html
+

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,4 +1,4 @@
-# Realising
+# Releasing
 
 For now, relasing is done manually.
 (See https://docs.scala-lang.org/overviews/contributors/index.html.)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,10 @@
 # Releasing
 
-For now, relasing is done manually.
+Releasing is done via Github:
+Just finish the release draft, prefilled from GitHub Actions.
+
+## OLD
+For now, releasing is done manually.
 (See https://docs.scala-lang.org/overviews/contributors/index.html.)
 
 Choose version:

--- a/build.sbt
+++ b/build.sbt
@@ -85,12 +85,12 @@ lazy val example = crossProject(JVMPlatform, JSPlatform)
   )
   .settings(sharedTestSettings)
   .settings(
-    crossScalaVersions := Seq(scalaVersion3, "2.13.12")
-    // scalacOptions ++= {
-    //   CrossVersion.partialVersion(scalaVersion.value) match {
-    //     case Some((2, 13)) => Seq("-Ytasty-reader")
-    //     case _             => Seq.empty
-    //   }
-    // }
+    crossScalaVersions := Seq(scalaVersion3, "2.13.12"),
+    scalacOptions ++= {
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, 13)) => Seq("-Ytasty-reader")
+        case _             => Seq.empty
+      }
+    }
   )
   .dependsOn(inlineFiles)

--- a/build.sbt
+++ b/build.sbt
@@ -25,9 +25,11 @@ lazy val sharedSettings = Seq(
   crossScalaVersions     := Nil
 )
 
-lazy val sharedHeaderSettings = Seq(
+lazy val sharedLintSettings = Seq(
   startYear := Some(2022),
-  licenses += ("Apache-2.0", new URL("https://www.apache.org/licenses/LICENSE-2.0.txt"))
+  licenses += ("Apache-2.0", new URL("https://www.apache.org/licenses/LICENSE-2.0.txt")),
+  semanticdbEnabled := true,
+  semanticdbVersion := scalafixSemanticdb.revision
 )
 
 lazy val sharedScalacSettings = Seq(
@@ -41,9 +43,7 @@ lazy val sharedScalacSettings = Seq(
       "-new-syntax",
       "-indent"
     )
-  },
-  semanticdbEnabled := true,
-  semanticdbVersion := scalafixSemanticdb.revision
+  }
 )
 
 lazy val sharedTestSettings = Seq(
@@ -61,7 +61,7 @@ lazy val root = project
   .aggregate(inlineFiles.jvm, inlineFiles.js)
   .aggregate(example.jvm, example.js)
   .settings(sharedSettings)
-  .settings(sharedHeaderSettings)
+  .settings(sharedLintSettings)
 
 lazy val inlineFiles = crossProject(JVMPlatform, JSPlatform)
   .crossType(CrossType.Pure)
@@ -71,7 +71,7 @@ lazy val inlineFiles = crossProject(JVMPlatform, JSPlatform)
     name := "inline-files"
   )
   .settings(sharedSettings)
-  .settings(sharedHeaderSettings)
+  .settings(sharedLintSettings)
   .settings(sharedScalacSettings)
   .settings(sharedTestSettings)
   .settings(scalacOptions ++= {
@@ -92,7 +92,7 @@ lazy val example = crossProject(JVMPlatform, JSPlatform)
     name           := "example",
     publish / skip := true
   )
-  .settings(sharedHeaderSettings)
+  .settings(sharedLintSettings)
   .settings(sharedTestSettings)
   .settings(
     crossScalaVersions := Seq(scalaVersion3, scalaVersion213),

--- a/build.sbt
+++ b/build.sbt
@@ -41,8 +41,9 @@ lazy val sharedScalacSettings = Seq(
       "-new-syntax",
       "-indent"
     )
-  }
-  // ThisBuild / semanticdbEnabled := true
+  },
+  semanticdbEnabled := true,
+  semanticdbVersion := scalafixSemanticdb.revision
 )
 
 lazy val sharedTestSettings = Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -15,9 +15,7 @@ lazy val sharedSettings = Seq(
   scalaVersion     := scalaVersion3,
   organization     := "io.github.frawa",
   organizationName := "Frank Wagner",
-  startYear        := Some(2022),
-  licenses += ("Apache-2.0", new URL("https://www.apache.org/licenses/LICENSE-2.0.txt")),
-  description := "A macro library to inline file contents.",
+  description      := "A macro library to inline file contents.",
   sonatypeProjectHosting := Some(
     GitHubHosting("frawa", "inline-files", "agilecoderfrank@gmail.com")
   ),
@@ -25,6 +23,11 @@ lazy val sharedSettings = Seq(
   sonatypeRepository     := "https://s01.oss.sonatype.org/service/local",
   versionScheme          := Some("semver-spec"),
   crossScalaVersions     := Nil
+)
+
+lazy val sharedHeaderSettings = Seq(
+  startYear := Some(2022),
+  licenses += ("Apache-2.0", new URL("https://www.apache.org/licenses/LICENSE-2.0.txt"))
 )
 
 lazy val sharedScalacSettings = Seq(
@@ -57,6 +60,7 @@ lazy val root = project
   .aggregate(inlineFiles.jvm, inlineFiles.js)
   .aggregate(example.jvm, example.js)
   .settings(sharedSettings)
+  .settings(sharedHeaderSettings)
 
 lazy val inlineFiles = crossProject(JVMPlatform, JSPlatform)
   .crossType(CrossType.Pure)
@@ -66,6 +70,7 @@ lazy val inlineFiles = crossProject(JVMPlatform, JSPlatform)
     name := "inline-files"
   )
   .settings(sharedSettings)
+  .settings(sharedHeaderSettings)
   .settings(sharedScalacSettings)
   .settings(sharedTestSettings)
   .settings(scalacOptions ++= {
@@ -86,6 +91,7 @@ lazy val example = crossProject(JVMPlatform, JSPlatform)
     name           := "example",
     publish / skip := true
   )
+  .settings(sharedHeaderSettings)
   .settings(sharedTestSettings)
   .settings(
     crossScalaVersions := Seq(scalaVersion3, scalaVersion213),

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,8 @@ addCommandAlias("fixCheck", "scalafixAll --check")
 addCommandAlias("fixFix", "scalafixAll")
 addCommandAlias("testAll", "test;+ test")
 
-lazy val scalaVersion3 = "3.3.3"
+lazy val scalaVersion3   = "3.3.3"
+lazy val scalaVersion213 = "2.13.13"
 
 import xerial.sbt.Sonatype._
 
@@ -47,7 +48,6 @@ lazy val sharedTestSettings = Seq(
 )
 
 lazy val rootFolder = file(".")
-
 lazy val root = project
   .in(rootFolder)
   .settings(
@@ -73,6 +73,9 @@ lazy val inlineFiles = crossProject(JVMPlatform, JSPlatform)
       s"-Xmacro-settings:MY_INLINE_HOME=${rootFolder.getAbsolutePath()}"
     )
   })
+  .settings(
+    libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion213
+  )
 
 lazy val example = crossProject(JVMPlatform, JSPlatform)
   .crossType(CrossType.Pure)
@@ -85,7 +88,7 @@ lazy val example = crossProject(JVMPlatform, JSPlatform)
   )
   .settings(sharedTestSettings)
   .settings(
-    crossScalaVersions := Seq(scalaVersion3, "2.13.12"),
+    crossScalaVersions := Seq(scalaVersion3, scalaVersion213),
     scalacOptions ++= {
       CrossVersion.partialVersion(scalaVersion.value) match {
         case Some((2, 13)) => Seq("-Ytasty-reader")

--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,10 @@
-addCommandAlias("lint", "headerCheckAll;fmtCheck;fixCheck;npmAll")
+addCommandAlias("lint", "headerCheckAll;fmtCheck;fixCheck")
 addCommandAlias("lintFix", "headerCreateAll;fixFix;fmtFix")
 addCommandAlias("fmtCheck", "all scalafmtCheck scalafmtSbtCheck")
 addCommandAlias("fmtFix", "all scalafmt scalafmtSbt")
 addCommandAlias("fixCheck", "scalafixAll --check")
 addCommandAlias("fixFix", "scalafixAll")
+addCommandAlias("testAll", "test;+ test")
 
 lazy val scalaVersion3 = "3.3.3"
 
@@ -21,11 +22,8 @@ lazy val sharedSettings = Seq(
   ),
   sonatypeCredentialHost := "s01.oss.sonatype.org",
   sonatypeRepository     := "https://s01.oss.sonatype.org/service/local",
-  versionScheme          := Some("semver-spec")
-)
-
-lazy val sharedPlatformSettings = Seq(
-  scalaVersion3
+  versionScheme          := Some("semver-spec"),
+  crossScalaVersions     := Nil
 )
 
 lazy val sharedScalacSettings = Seq(
@@ -57,6 +55,7 @@ lazy val root = project
     publish / skip := true
   )
   .aggregate(inlineFiles.jvm, inlineFiles.js)
+  .aggregate(example.jvm, example.js)
   .settings(sharedSettings)
 
 lazy val inlineFiles = crossProject(JVMPlatform, JSPlatform)
@@ -74,3 +73,24 @@ lazy val inlineFiles = crossProject(JVMPlatform, JSPlatform)
       s"-Xmacro-settings:MY_INLINE_HOME=${rootFolder.getAbsolutePath()}"
     )
   })
+
+lazy val example = crossProject(JVMPlatform, JSPlatform)
+  .crossType(CrossType.Pure)
+  .withoutSuffixFor(JVMPlatform)
+  .in(file("example"))
+  .settings(
+    scalaVersion   := scalaVersion3,
+    name           := "example",
+    publish / skip := true
+  )
+  .settings(sharedTestSettings)
+  .settings(
+    crossScalaVersions := Seq(scalaVersion3, "2.13.12")
+    // scalacOptions ++= {
+    //   CrossVersion.partialVersion(scalaVersion.value) match {
+    //     case Some((2, 13)) => Seq("-Ytasty-reader")
+    //     case _             => Seq.empty
+    //   }
+    // }
+  )
+  .dependsOn(inlineFiles)

--- a/example/src/main/scala/example/Example.scala
+++ b/example/src/main/scala/example/Example.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 example
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package example
 
 import frawa.inlinefiles.InlineFiles._

--- a/example/src/main/scala/example/Example.scala
+++ b/example/src/main/scala/example/Example.scala
@@ -1,7 +1,9 @@
 package example
 
-import frawa.inlinefiles.InlineFiles.inlineTextFile
+import frawa.inlinefiles.InlineFiles._
 
 object Example {
-  val inlinedText = inlineTextFile("./test-files/inlined.txt")
+  val inlinedText          = inlineTextFile("./test-files/inlined.txt")
+  val inlinedTextFiles     = inlineTextFiles("./test-files/folder", ".txt")
+  val inlinedDeepTextFiles = inlineDeepTextFiles("./test-files/folder", ".txt")
 }

--- a/example/src/main/scala/example/Example.scala
+++ b/example/src/main/scala/example/Example.scala
@@ -1,5 +1,7 @@
 package example
 
+import frawa.inlinefiles.InlineFiles.inlineTextFile
+
 object Example {
-  val inlinedText = "foo"
+  val inlinedText = inlineTextFile("./test-files/inlined.txt")
 }

--- a/example/src/main/scala/example/Example.scala
+++ b/example/src/main/scala/example/Example.scala
@@ -1,0 +1,5 @@
+package example
+
+object Example {
+  val inlinedText = "foo"
+}

--- a/example/src/test/scala/example/ExampleTest.scala
+++ b/example/src/test/scala/example/ExampleTest.scala
@@ -5,6 +5,28 @@ import munit.FunSuite
 class ExampleTest extends FunSuite {
 
   test("inlined text") {
-    assertEquals("This file content will be inlined.", Example.inlinedText)
+    assertEquals(Example.inlinedText, "This file content will be inlined.")
   }
+
+  test("inline files in a folder") {
+    assertEquals(
+      Example.inlinedTextFiles,
+      Map(
+        "inlined1.txt" -> "First",
+        "inlined2.txt" -> "Second"
+      )
+    )
+  }
+
+  test("inline files in nested folders") {
+    assertEquals(
+      Example.inlinedDeepTextFiles,
+      Map(
+        "inlined1.txt"      -> "First",
+        "inlined2.txt"      -> "Second",
+        "deep/inlined3.txt" -> "Third\nand more"
+      )
+    )
+  }
+
 }

--- a/example/src/test/scala/example/ExampleTest.scala
+++ b/example/src/test/scala/example/ExampleTest.scala
@@ -5,6 +5,6 @@ import munit.FunSuite
 class ExampleTest extends FunSuite {
 
   test("inlined text") {
-    assertEquals("foo", Example.inlinedText)
+    assertEquals("This file content will be inlined.", Example.inlinedText)
   }
 }

--- a/example/src/test/scala/example/ExampleTest.scala
+++ b/example/src/test/scala/example/ExampleTest.scala
@@ -1,0 +1,10 @@
+package example
+
+import munit.FunSuite
+
+class ExampleTest extends FunSuite {
+
+  test("inlined text") {
+    assertEquals("foo", Example.inlinedText)
+  }
+}

--- a/example/src/test/scala/example/ExampleTest.scala
+++ b/example/src/test/scala/example/ExampleTest.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 example
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package example
 
 import munit.FunSuite

--- a/inline-files/src/main/scala/frawa/inlinefiles/InlineFiles.scala
+++ b/inline-files/src/main/scala/frawa/inlinefiles/InlineFiles.scala
@@ -17,9 +17,8 @@
 package frawa.inlinefiles
 
 import scala.quoted.*
-import frawa.inlinefiles.compiletime.FileContents.readTextContentOf
-import frawa.inlinefiles.compiletime.FileContents.readTextContentsIn
-import frawa.inlinefiles.compiletime.FileContents.readDeepTextContentsIn
+import frawa.inlinefiles.compiletime.FileContents.*
+import scala.collection.immutable.ListMap
 
 object InlineFiles:
   import compiletime.FileContents.{given, *}
@@ -68,15 +67,53 @@ object InlineFiles:
 
   // Scala 2 macros
   def inlineTextFile(path: String): String = macro Compat.inlineTextFileImpl
+  def inlineTextFiles(path: String, ext: String): Map[String, String] = macro
+    Compat.inlineTextFilesImpl
+  def inlineDeepTextFiles(path: String, ext: String): Map[String, String] = macro
+    Compat.inlineDeepTextFilesImpl
 
   private object Compat {
     import scala.language.experimental.macros
     import scala.reflect.macros.blackbox.Context
+
     def inlineTextFileImpl(c: Context)(path: c.Expr[String]): c.Tree = {
       import c.universe._
 
       val Literal(Constant(p: String)) = path.tree: @unchecked
       val content                      = readTextContentOf(p)
       Literal(Constant(content))
+    }
+
+    def inlineTextFilesImpl(c: Context)(path: c.Expr[String], ext: c.Expr[String]): c.Tree = {
+      import c.universe._
+
+      val Literal(Constant(p: String)) = path.tree: @unchecked
+      val Literal(Constant(e: String)) = ext.tree: @unchecked
+      val content                      = readTextContentsIn(p, e)
+      reifyMap(c)(content)
+    }
+
+    def inlineDeepTextFilesImpl(c: Context)(path: c.Expr[String], ext: c.Expr[String]): c.Tree = {
+      import c.universe._
+
+      val Literal(Constant(p: String)) = path.tree: @unchecked
+      val Literal(Constant(e: String)) = ext.tree: @unchecked
+      val content                      = readDeepTextContentsIn(p, e)
+      reifyMap(c)(content)
+    }
+
+    private def reifyMap(c: Context)(m: Map[String, String]): c.Tree = {
+      import c.universe._
+
+      val tuple2Apply = Select(Ident(TermName("Tuple2")), TermName("apply"))
+      val mapApply    = Select(Ident(TermName("Map")), TermName("apply"))
+
+      val pairs = m.map { (k, v) =>
+        val key   = Literal(Constant(k))
+        val value = Literal(Constant(v))
+        Apply(tuple2Apply, List(key, value))
+      }.toList
+
+      Apply(mapApply, pairs)
     }
   }

--- a/inline-files/src/main/scala/frawa/inlinefiles/InlineFiles.scala
+++ b/inline-files/src/main/scala/frawa/inlinefiles/InlineFiles.scala
@@ -25,8 +25,6 @@ object InlineFiles:
   import compiletime.FileContents.{given, *}
   import scala.language.experimental.macros
 
-  def inlineTextFile(path: String): String = macro Compat.inlineTextFileImpl
-
   inline def inlineTextFile(inline path: String): String = ${
     inlineTextFile_impl('path)
   }
@@ -69,13 +67,15 @@ object InlineFiles:
     Expr(readDeepTextContentsIn(path.valueOrAbort, ext.valueOrAbort))
 
   // Scala 2 macros
+  def inlineTextFile(path: String): String = macro Compat.inlineTextFileImpl
+
   private object Compat {
     import scala.language.experimental.macros
     import scala.reflect.macros.blackbox.Context
     def inlineTextFileImpl(c: Context)(path: c.Expr[String]): c.Tree = {
       import c.universe._
 
-      val Literal(Constant(p: String)) = path.tree
+      val Literal(Constant(p: String)) = path.tree: @unchecked
       val content                      = readTextContentOf(p)
       Literal(Constant(content))
     }

--- a/inline-files/src/main/scala/frawa/inlinefiles/compiletime/FileContents.scala
+++ b/inline-files/src/main/scala/frawa/inlinefiles/compiletime/FileContents.scala
@@ -22,6 +22,7 @@ import scala.jdk.CollectionConverters.*
 
 import scala.io.Source
 import scala.util.Using
+import scala.collection.immutable.Seq
 
 import scala.annotation.experimental
 

--- a/inline-files/src/test/scala/frawa/inlinefiles/InlineFilesTest.scala
+++ b/inline-files/src/test/scala/frawa/inlinefiles/InlineFilesTest.scala
@@ -17,6 +17,7 @@
 package frawa.inlinefiles
 
 import InlineFiles.*
+import scala.collection.immutable.Seq
 
 import munit.FunSuite
 

--- a/inline-files/src/test/scala/frawa/inlinefiles/InlineFilesWithHomeTest.scala
+++ b/inline-files/src/test/scala/frawa/inlinefiles/InlineFilesWithHomeTest.scala
@@ -16,6 +16,8 @@
 
 package frawa.inlinefiles
 
+import scala.collection.immutable.Seq
+
 import munit.FunSuite
 import scala.annotation.experimental
 

--- a/inline-files/src/test/scala/frawa/inlinefiles/Words.scala
+++ b/inline-files/src/test/scala/frawa/inlinefiles/Words.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Frank Wagner
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package frawa.inlinefiles
 
 import scala.collection.immutable.Seq

--- a/inline-files/src/test/scala/frawa/inlinefiles/Words.scala
+++ b/inline-files/src/test/scala/frawa/inlinefiles/Words.scala
@@ -1,5 +1,6 @@
 package frawa.inlinefiles
 
+import scala.collection.immutable.Seq
 import scala.quoted.*
 import frawa.inlinefiles.compiletime.FileContents
 

--- a/inline-files/src/test/scala/frawa/inlinefiles/WordsWithHome.scala
+++ b/inline-files/src/test/scala/frawa/inlinefiles/WordsWithHome.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Frank Wagner
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package frawa.inlinefiles
 
 import scala.collection.immutable.Seq

--- a/inline-files/src/test/scala/frawa/inlinefiles/WordsWithHome.scala
+++ b/inline-files/src/test/scala/frawa/inlinefiles/WordsWithHome.scala
@@ -1,5 +1,6 @@
 package frawa.inlinefiles
 
+import scala.collection.immutable.Seq
 import scala.quoted.*
 import frawa.inlinefiles.compiletime.FileContents
 import scala.annotation.experimental


### PR DESCRIPTION
Mix macro implementations with Scala 2.13, like described [here](https://docs.scala-lang.org/scala3/guides/migration/tutorial-macro-mixing.html).